### PR TITLE
Fix incorrect node name and ros2 time

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Sample models are available [here](https://github.com/luxonis/depthai/tree/main/
     Note: `colcon build` will also work with ROS1
 1. Run the Nodelet
     ```bash
-    ros2 run depthai_ros_driver depthai_ros_driver_node
+    ros2 run depthai_ros_driver depthai_ros_driver_depthai_ros_driver_node
     ```
 2. Or, Run: ROS2 `composition`. Similar concept of `nodelet`. To run it:
     ```bash
@@ -96,7 +96,7 @@ This package consists of a node and a nodelet version of the ROS driver. It also
 ## `node_interface`
 This package contains some utilities used to reduce code duplication between the node and the nodelet version in `depthai_ros_driver`.
 
-# Notes (TO REMOVE)
+## Notes (TO REMOVE)
 
 Interface test
 ```bash

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Sample models are available [here](https://github.com/luxonis/depthai/tree/main/
     Note: `colcon build` will also work with ROS1
 1. Run the Nodelet
     ```bash
-    ros2 run depthai_ros_driver depthai_ros_driver_depthai_ros_driver_node
+    ros2 run depthai_ros_driver depthai_ros_driver_node
     ```
 2. Or, Run: ROS2 `composition`. Similar concept of `nodelet`. To run it:
     ```bash

--- a/depthai_cmake/depthai_cmake_macros.cmake.in
+++ b/depthai_cmake/depthai_cmake_macros.cmake.in
@@ -128,10 +128,10 @@ macro(add_ros_node name)
     add_dependencies(${name}
       ${${name}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
-    add_executable(${PROJECT_NAME}_${name}_node ${_ARG_ROS1_EXE_SOURCES})
-    target_link_libraries(${PROJECT_NAME}_${name}_node ${name})
+    add_executable(${name}_node ${_ARG_ROS1_EXE_SOURCES})
+    target_link_libraries(${name}_node ${name})
 
-    install(TARGETS ${name} ${PROJECT_NAME}_${name}_node
+    install(TARGETS ${name} ${name}_node
       ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
       LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
       RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
@@ -172,8 +172,8 @@ macro(add_ros_node name)
     # register lib as component
     rclcpp_components_register_nodes(${name} ${_ARG_ROS2_COMPONENT_CLASS})
 
-    add_executable(${PROJECT_NAME}_${name}_node ${_ARG_ROS2_EXE_SOURCES})
-    target_link_libraries(${PROJECT_NAME}_${name}_node PUBLIC ${name})
+    add_executable(${name}_node ${_ARG_ROS2_EXE_SOURCES})
+    target_link_libraries(${name}_node PUBLIC ${name})
 
     install(TARGETS
       ${name}
@@ -182,7 +182,7 @@ macro(add_ros_node name)
       RUNTIME DESTINATION bin)
 
     install(TARGETS
-      ${PROJECT_NAME}_${name}_node
+      ${name}_node
       DESTINATION lib/${_ARG_PROJECT_NAME})
 
     install(DIRECTORY ${_ARG_DIRECTORIES}

--- a/depthai_ros_driver/CMakeLists.txt
+++ b/depthai_ros_driver/CMakeLists.txt
@@ -61,7 +61,6 @@ find_dependent_packages(${PKG_DEPS})
 
 add_subdirectory(${DEPTHAI_CORE} depthai-core)
 
-# exe_name is named as ${PROJECT_NAME}_${name}_node
 add_ros_node(depthai_ros_driver
   PROJECT_NAME ${PROJECT_NAME}
   SOURCES src/depthai_common.cpp

--- a/depthai_ros_driver/CMakeLists.txt
+++ b/depthai_ros_driver/CMakeLists.txt
@@ -61,6 +61,7 @@ find_dependent_packages(${PKG_DEPS})
 
 add_subdirectory(${DEPTHAI_CORE} depthai-core)
 
+# exe_name is named as ${PROJECT_NAME}_${name}_node
 add_ros_node(depthai_ros_driver
   PROJECT_NAME ${PROJECT_NAME}
   SOURCES src/depthai_common.cpp

--- a/depthai_ros_driver/include/depthai_ros_driver/impl/ros_agnostic.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/impl/ros_agnostic.hpp
@@ -200,6 +200,16 @@ void get_param(
 #endif
 }
 
+//==============================================================================
+RosDuration from_seconds(const double ts_sec)
+{
+  #if defined(USE_ROS2)
+  return RosDuration(ts_sec*1e9);
+  #else
+  return RosDuration(ts_sec);
+  #endif
+}
+
 }  // namespace ros_agnostic
 }  // namespace rr
 

--- a/depthai_ros_driver/include/depthai_ros_driver/ros_agnostic.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/ros_agnostic.hpp
@@ -173,6 +173,11 @@ void get_param(
   const std::string& name,
   Param& variable);
 
+//==============================================================================
+
+/// @brief convert sec to rosduration
+inline RosDuration from_seconds(const double ts_sec);
+
 }  // namespace ros_agnostic
 }  // namespace rr
 

--- a/depthai_ros_driver/launch/depthai_node.launch
+++ b/depthai_ros_driver/launch/depthai_node.launch
@@ -50,8 +50,8 @@
 
   <!-- Launch the Depthai node -->
   <group ns="$(arg ns)">
-    <node pkg="depthai_ros_driver" type="depthai_ros_driver_node" name="$(arg node_name)"
-          output="screen" launch-prefix="$(arg launch_prefix)">
+    <node pkg="depthai_ros_driver" type="depthai_ros_driver_depthai_ros_driver_node"
+          name="$(arg node_name)" output="screen" launch-prefix="$(arg launch_prefix)">
 
       <param name="camera_name" value="$(arg camera_name)"/>
       <param name="cmd_file" value="$(arg cmd_file)"/>

--- a/depthai_ros_driver/launch/depthai_node.launch
+++ b/depthai_ros_driver/launch/depthai_node.launch
@@ -50,7 +50,7 @@
 
   <!-- Launch the Depthai node -->
   <group ns="$(arg ns)">
-    <node pkg="depthai_ros_driver" type="depthai_ros_driver_depthai_ros_driver_node"
+    <node pkg="depthai_ros_driver" type="depthai_ros_driver_node"
           name="$(arg node_name)" output="screen" launch-prefix="$(arg launch_prefix)">
 
       <param name="camera_name" value="$(arg camera_name)"/>

--- a/depthai_ros_driver/launch/depthai_node.launch.xml
+++ b/depthai_ros_driver/launch/depthai_node.launch.xml
@@ -53,8 +53,8 @@
   <arg name="stream_list" default="[left, right, metaout, previewout, disparity, disparity_color, depth, video]"/>
 
   <group>
-    <node pkg="depthai_ros_driver" exec="depthai_ros_driver_node" name="$(var node_name)"
-      output="screen" launch-prefix="$(var launch_prefix)">
+    <node pkg="depthai_ros_driver" exec="depthai_ros_driver_depthai_ros_driver_node"
+          name="$(var node_name)" output="screen" launch-prefix="$(var launch_prefix)">
       <param name="camera_name" value="$(var camera_name)"/>
 
       <param name="cmd_file" value="$(var cmd_file)"/>

--- a/depthai_ros_driver/launch/depthai_node.launch.xml
+++ b/depthai_ros_driver/launch/depthai_node.launch.xml
@@ -53,7 +53,7 @@
   <arg name="stream_list" default="[left, right, metaout, previewout, disparity, disparity_color, depth, video]"/>
 
   <group>
-    <node pkg="depthai_ros_driver" exec="depthai_ros_driver_depthai_ros_driver_node"
+    <node pkg="depthai_ros_driver" exec="depthai_ros_driver_node"
           name="$(var node_name)" output="screen" launch-prefix="$(var launch_prefix)">
       <param name="camera_name" value="$(var camera_name)"/>
 

--- a/depthai_ros_driver/src/depthai_common.cpp
+++ b/depthai_ros_driver/src/depthai_common.cpp
@@ -548,7 +548,7 @@ const RosTime DepthAICommon::get_rostime(const double camera_ts)
     _depthai_init_ts = camera_ts;
     _stamp = _node_interface.current_time();
   }
-  return _stamp + RosDuration(camera_ts - _depthai_init_ts);
+  return _stamp + ros_agnostic::from_seconds(camera_ts - _depthai_init_ts);
 }
 
 }  // namespace rr


### PR DESCRIPTION
Quick fix to update all corresponding node_names to `depthai_ros_driver_depthai_ros_driver_node`, after changing node name to 
```
    add_executable(${PROJECT_NAME}_${name}_node .... )
``` 
according to https://github.com/osrf/depthai_ros/pull/4#discussion_r715195586


**Updated:  
 - revert node name back to  add_executable(${name}_node .... )
 - Also fix nano sec on rosDuration conversion.

